### PR TITLE
Add ToyimBor landing page demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
+# Obidbek
+
 - 👋 Hi, I’m @Obidbek
 - 👀 I’m interested in ...
 - 🌱 I’m currently learning ...
 - 💞️ I’m looking to collaborate on ...
 - 📫 How to reach me ...
 
-<!---
-Obidbek/Obidbek is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+## Project Docs
+- [To'yimBor — To'liq dizayn va texnik brief](docs/toyimbor-design-brief.md)
+
+## Demo
+- [To'yimBor demo sahifasi](demo/index.html)

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,390 @@
+<!DOCTYPE html>
+<html lang="uz">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>To'yimBor — Demo</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700&family=Poppins:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-inner">
+        <a class="logo" href="#">To'yimBor</a>
+        <nav class="main-nav" aria-label="Primary">
+          <a href="#hero">Bosh sahifa</a>
+          <a href="#catalog">To' yxonalar</a>
+          <a href="#blog">Blog</a>
+          <a href="#contact">Aloqa</a>
+        </nav>
+        <div class="auth-actions">
+          <button class="btn ghost">Kirish</button>
+          <button class="btn primary">Ro'yxatdan o'tish</button>
+        </div>
+        <button class="mobile-menu" aria-label="Menyuni ochish">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <main>
+      <section id="hero" class="hero">
+        <div class="container hero-inner">
+          <div class="hero-copy">
+            <p class="eyebrow">Zamonaviy to'yxonalar katalogi</p>
+            <h1>To'y marosimingiz uchun ideal joyni toping</h1>
+            <p>
+              To'yimBor sizga shahar bo'ylab eng mashhur to'yxonalarni qidirish,
+              bo'sh sanalarni tekshirish va atigi bir necha qadamda band qilish
+              imkonini beradi.
+            </p>
+            <div class="hero-actions">
+              <a class="btn primary" href="#catalog">Katalogni ko'rish</a>
+              <a class="btn secondary" href="#flow">Band qilish jarayoni</a>
+            </div>
+          </div>
+          <div class="hero-search">
+            <form class="search-card" aria-label="To'yxona qidiruv formasi">
+              <h2>Orzuingizdagi to'yxonani toping</h2>
+              <label class="field">
+                <span>Joy nomi yoki to'yxona</span>
+                <input
+                  type="text"
+                  name="query"
+                  placeholder="🔍 Joy nomi, to'yxona yoki xizmat qidiring"
+                />
+              </label>
+              <label class="field">
+                <span>Sana</span>
+                <input type="date" name="date" />
+              </label>
+              <div class="field grid">
+                <button type="button" class="btn secondary">
+                  <span class="icon">⚙️</span>
+                  Filtrlar
+                </button>
+                <button type="submit" class="btn primary">Qidirish</button>
+              </div>
+              <p class="hint">
+                Sana kiritilmasa barcha mavjud to'yxonalar ko'rsatiladi.
+              </p>
+            </form>
+          </div>
+        </div>
+      </section>
+
+      <section id="catalog" class="section bg-light">
+        <div class="container">
+          <div class="section-heading">
+            <h2>Mashhur to'yxonalar</h2>
+            <p>Shahar bo'ylab foydalanuvchilarimiz tavsiya qilgan joylar.</p>
+          </div>
+          <div class="cards-grid">
+            <article class="venue-card">
+              <div class="media" role="img" aria-label="Afsonaviy to'yxona">
+                <div class="badge">Video</div>
+              </div>
+              <div class="card-body">
+                <div class="card-top">
+                  <h3>Afsonaviy To'yxona</h3>
+                  <button class="icon-btn" aria-label="Sevimlilarga qo'shish">☆</button>
+                </div>
+                <p class="meta">500 kishigacha · Qarshi, Mustaqillik ko'chasi</p>
+                <ul class="amenities">
+                  <li>🚗 Parking</li>
+                  <li>🎉 Dekor</li>
+                  <li>❄️ Konditsioner</li>
+                </ul>
+                <div class="card-footer">
+                  <div class="price">
+                    <span>6 500 000 so'mdan</span>
+                    <span class="rating">⭐ 4.8</span>
+                  </div>
+                  <button class="btn primary">Band qilish</button>
+                </div>
+              </div>
+            </article>
+
+            <article class="venue-card">
+              <div class="media" role="img" aria-label="Zarafshon palace"></div>
+              <div class="card-body">
+                <div class="card-top">
+                  <h3>Zarafshon Palace</h3>
+                  <button class="icon-btn" aria-label="Sevimlilarga qo'shish">☆</button>
+                </div>
+                <p class="meta">350 kishigacha · Samarqand, Registon ko'chasi</p>
+                <ul class="amenities">
+                  <li>📶 Wi-Fi</li>
+                  <li>🎤 Jonli musiqa</li>
+                  <li>🎥 LED ekran</li>
+                </ul>
+                <div class="card-footer">
+                  <div class="price">
+                    <span>5 200 000 so'mdan</span>
+                    <span class="rating">⭐ 4.7</span>
+                  </div>
+                  <button class="btn primary">Band qilish</button>
+                </div>
+              </div>
+            </article>
+
+            <article class="venue-card">
+              <div class="media" role="img" aria-label="Luxor wedding hall"></div>
+              <div class="card-body">
+                <div class="card-top">
+                  <h3>Luxor Wedding Hall</h3>
+                  <button class="icon-btn" aria-label="Sevimlilarga qo'shish">☆</button>
+                </div>
+                <p class="meta">420 kishigacha · Toshkent, Yakkasaroy tumani</p>
+                <ul class="amenities">
+                  <li>🍽️ Catering</li>
+                  <li>🎇 Pirotexnika</li>
+                  <li>🅿️ VIP parking</li>
+                </ul>
+                <div class="card-footer">
+                  <div class="price">
+                    <span>7 800 000 so'mdan</span>
+                    <span class="rating">⭐ 4.9</span>
+                  </div>
+                  <button class="btn primary">Band qilish</button>
+                </div>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="flow" class="section">
+        <div class="container flow">
+          <div class="section-heading">
+            <h2>Band qilish jarayoni</h2>
+            <p>Foydalanuvchilar uchun oddiy va ishonchli to'lov jarayoni.</p>
+          </div>
+          <ol class="steps" aria-label="Band qilish bosqichlari">
+            <li>
+              <span class="step-number">1</span>
+              Qidiruv paneli orqali manzil va sanani tanlang.
+            </li>
+            <li>
+              <span class="step-number">2</span>
+              To'yxona kartasidan batafsil ma'lumot va mavjudlikni ko'ring.
+            </li>
+            <li>
+              <span class="step-number">3</span>
+              Sana va slotni belgilang, hold taymeri bilan tasdiqlang.
+            </li>
+            <li>
+              <span class="step-number">4</span>
+              Onlayn to'lovni amalga oshiring va tasdiqlash xabarini oling.
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section id="calendar" class="section bg-light">
+        <div class="container calendar-demo">
+          <div class="section-heading">
+            <h2>Band qilish taqvimi</h2>
+            <p>Slot darajasida mavjudlikni aniq ko'ring.</p>
+          </div>
+          <div class="calendar-widget" role="application" aria-label="Avgust 2025 taqvimi">
+            <div class="calendar-header">
+              <button aria-label="Oldingi oy">‹</button>
+              <div>
+                <span class="month">Avgust 2025</span>
+                <span class="legend">
+                  <span class="dot available"></span> Bo'sh
+                  <span class="dot partial"></span> Qisman
+                  <span class="dot booked"></span> Band
+                </span>
+              </div>
+              <button aria-label="Keyingi oy">›</button>
+            </div>
+            <div class="calendar-grid">
+              <div class="day">Du</div>
+              <div class="day">Se</div>
+              <div class="day">Ch</div>
+              <div class="day">Pa</div>
+              <div class="day">Ju</div>
+              <div class="day">Sh</div>
+              <div class="day">Ya</div>
+              <div class="cell muted">28</div>
+              <div class="cell muted">29</div>
+              <div class="cell muted">30</div>
+              <div class="cell muted">31</div>
+              <button class="cell available" type="button">
+                <span class="date">1</span>
+                <span class="slots">
+                  <span class="slot morning">Ertalab</span>
+                  <span class="slot evening">Kechki</span>
+                </span>
+              </button>
+              <button class="cell partial" type="button">
+                <span class="date">2</span>
+                <span class="slots">
+                  <span class="slot morning disabled">Ertalab</span>
+                  <span class="slot evening">Kechki</span>
+                </span>
+              </button>
+              <button class="cell booked" type="button" disabled>
+                <span class="date">3</span>
+                <span class="slots">
+                  <span class="slot morning disabled">Band</span>
+                  <span class="slot evening disabled">Band</span>
+                </span>
+              </button>
+              <button class="cell available" type="button">
+                <span class="date">4</span>
+                <span class="slots">
+                  <span class="slot morning">Ertalab</span>
+                  <span class="slot evening">Kechki</span>
+                </span>
+              </button>
+              <button class="cell available" type="button">
+                <span class="date">5</span>
+                <span class="slots">
+                  <span class="slot morning">Ertalab</span>
+                  <span class="slot evening">Kechki</span>
+                </span>
+              </button>
+              <button class="cell partial" type="button">
+                <span class="date">6</span>
+                <span class="slots">
+                  <span class="slot morning">Ertalab</span>
+                  <span class="slot evening disabled">Kechki</span>
+                </span>
+              </button>
+              <button class="cell booked" type="button" disabled>
+                <span class="date">7</span>
+                <span class="slots">
+                  <span class="slot morning disabled">Band</span>
+                  <span class="slot evening disabled">Band</span>
+                </span>
+              </button>
+              <button class="cell available" type="button">
+                <span class="date">8</span>
+                <span class="slots">
+                  <span class="slot morning">Ertalab</span>
+                  <span class="slot evening">Kechki</span>
+                </span>
+              </button>
+              <button class="cell available" type="button">
+                <span class="date">9</span>
+                <span class="slots">
+                  <span class="slot morning">Ertalab</span>
+                  <span class="slot evening">Kechki</span>
+                </span>
+              </button>
+              <button class="cell partial" type="button">
+                <span class="date">10</span>
+                <span class="slots">
+                  <span class="slot morning disabled">Ertalab</span>
+                  <span class="slot evening">Kechki</span>
+                </span>
+              </button>
+              <button class="cell booked" type="button" disabled>
+                <span class="date">11</span>
+                <span class="slots">
+                  <span class="slot morning disabled">Band</span>
+                  <span class="slot evening disabled">Band</span>
+                </span>
+              </button>
+              <button class="cell available" type="button">
+                <span class="date">12</span>
+                <span class="slots">
+                  <span class="slot morning">Ertalab</span>
+                  <span class="slot evening">Kechki</span>
+                </span>
+              </button>
+            </div>
+            <div class="slot-panel">
+              <h3>Tanlangan sana: <span>2-avgust, 2025</span></h3>
+              <div class="slot-options">
+                <button class="slot-chip disabled">Ertalab 10:00–15:00</button>
+                <button class="slot-chip">Kechki 17:00–22:00</button>
+              </div>
+              <div class="hold-timer">Rezervni yakunlash uchun: 09:45</div>
+              <button class="btn primary">Band qilish</button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="blog" class="section">
+        <div class="container blog">
+          <div class="section-heading">
+            <h2>Blog yangiliklari</h2>
+            <p>To'y tashkil etishga oid foydali maslahatlar va trendlar.</p>
+          </div>
+          <div class="blog-grid">
+            <article class="blog-card">
+              <h3>To'y dekoridagi 5 ta zamonaviy g'oya</h3>
+              <p>
+                Milliy naqsh va zamonaviy minimalizm uyg'unligida orzudagi dekorni
+                yaratish bo'yicha tavsiyalar.
+              </p>
+              <a href="#" class="link">Batafsil o'qish →</a>
+            </article>
+            <article class="blog-card">
+              <h3>To'yxonani band qilishda nimalarga e'tibor berish kerak?</h3>
+              <p>
+                Narx, xizmatlar, logistika va texnik ta'minot bo'yicha tekshiruv
+                ro'yxatini yuklab oling.
+              </p>
+              <a href="#" class="link">Batafsil o'qish →</a>
+            </article>
+            <article class="blog-card">
+              <h3>Qishki to'ylar uchun ilhom manbalari</h3>
+              <p>
+                Yorug'lik, ranglar va menyu bo'yicha ijodiy yechimlar bilan
+                mehmonlaringizni hayratda qoldiring.
+              </p>
+              <a href="#" class="link">Batafsil o'qish →</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section cta">
+        <div class="container">
+          <h2>Loyihani ishga tushirishga tayyormisiz?</h2>
+          <p>
+            To'yimBor demo versiyasi Figma dizayn va backend integratsiyasi bilan
+            birga to'liq ishlovchi mahsulotga aylanadi.
+          </p>
+          <div class="hero-actions">
+            <a class="btn primary" href="mailto:hello@toyimbor.uz">Bog'lanish</a>
+            <a class="btn secondary" href="docs/toyimbor-design-brief.md">Texnik brief</a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-inner">
+        <p>© 2025 To'yimBor. Barcha huquqlar himoyalangan.</p>
+        <div class="social-links">
+          <a href="#" aria-label="Telegram">Telegram</a>
+          <a href="#" aria-label="Instagram">Instagram</a>
+          <a href="#" aria-label="YouTube">YouTube</a>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      const menuButton = document.querySelector('.mobile-menu');
+      const nav = document.querySelector('.main-nav');
+      menuButton?.addEventListener('click', () => {
+        menuButton.classList.toggle('open');
+        nav.classList.toggle('open');
+      });
+    </script>
+  </body>
+</html>

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -1,0 +1,738 @@
+:root {
+  --color-primary: #123e2d;
+  --color-gold: #d4af37;
+  --color-bg: #f8f3e7;
+  --color-text: #333333;
+  --color-white: #ffffff;
+  --shadow-soft: 0 20px 40px rgba(18, 62, 45, 0.1);
+  --radius-lg: 16px;
+  --radius-md: 12px;
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 16px;
+  --spacing-lg: 24px;
+  --spacing-xl: 32px;
+  --font-heading: 'Montserrat', sans-serif;
+  --font-body: 'Poppins', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background: var(--color-white);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1120px, 90vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid rgba(18, 62, 45, 0.1);
+}
+
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-md) 0;
+  gap: var(--spacing-lg);
+}
+
+.logo {
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 1.3rem;
+  letter-spacing: 0.08em;
+  color: var(--color-primary);
+}
+
+.main-nav {
+  display: flex;
+  gap: var(--spacing-lg);
+  font-weight: 500;
+}
+
+.main-nav a {
+  position: relative;
+  padding-bottom: 4px;
+}
+
+.main-nav a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--color-gold);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+}
+
+.main-nav a:focus-visible,
+.main-nav a:hover {
+  color: var(--color-primary);
+}
+
+.main-nav a:hover::after,
+.main-nav a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.auth-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.btn {
+  font-family: var(--font-body);
+  font-weight: 500;
+  border-radius: var(--radius-md);
+  border: none;
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+}
+
+.btn.primary {
+  background: var(--color-primary);
+  color: var(--color-white);
+  box-shadow: 0 10px 20px rgba(18, 62, 45, 0.2);
+}
+
+.btn.primary:hover,
+.btn.primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(18, 62, 45, 0.25);
+}
+
+.btn.secondary {
+  background: var(--color-gold);
+  color: var(--color-primary);
+}
+
+.btn.secondary:hover,
+.btn.secondary:focus-visible {
+  transform: translateY(-2px);
+}
+
+.btn.ghost {
+  background: transparent;
+  border: 1px solid rgba(18, 62, 45, 0.25);
+  color: var(--color-primary);
+}
+
+.btn.ghost:hover,
+.btn.ghost:focus-visible {
+  background: rgba(18, 62, 45, 0.05);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 2px;
+}
+
+.mobile-menu {
+  display: none;
+  flex-direction: column;
+  gap: 6px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.mobile-menu span {
+  width: 24px;
+  height: 2px;
+  background: var(--color-primary);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.hero {
+  background: linear-gradient(120deg, rgba(18, 62, 45, 0.06), transparent),
+    url('https://images.unsplash.com/photo-1520854221050-0f4caff449fb?auto=format&fit=crop&w=1600&q=80')
+      no-repeat center/cover;
+  color: var(--color-primary);
+  padding: 120px 0 80px;
+  position: relative;
+}
+
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, rgba(248, 243, 231, 0.92), rgba(248, 243, 231, 0.6));
+}
+
+.hero-inner {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: var(--spacing-xl);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.hero-copy h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 4vw, 3.2rem);
+  margin-bottom: var(--spacing-md);
+}
+
+.hero-copy .eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  color: var(--color-gold);
+  font-weight: 600;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  margin-top: var(--spacing-md);
+}
+
+.search-card {
+  background: var(--color-white);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  padding: var(--spacing-xl);
+  border: 1px solid rgba(212, 175, 55, 0.3);
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.search-card h2 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 1.4rem;
+  color: var(--color-primary);
+}
+
+.field {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.field span {
+  font-weight: 500;
+}
+
+.field input {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(18, 62, 45, 0.2);
+  padding: 0.75rem 1rem;
+  font-family: var(--font-body);
+  font-size: 1rem;
+}
+
+.field.grid {
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-sm);
+}
+
+.field.grid .btn {
+  width: 100%;
+}
+
+.hint {
+  font-size: 0.85rem;
+  color: rgba(51, 51, 51, 0.7);
+}
+
+.section {
+  padding: 80px 0;
+}
+
+.section.bg-light {
+  background: var(--color-bg);
+}
+
+.section-heading {
+  text-align: center;
+  margin-bottom: var(--spacing-xl);
+}
+
+.section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  margin-bottom: var(--spacing-sm);
+}
+
+.cards-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--spacing-xl);
+}
+
+.venue-card {
+  background: var(--color-white);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid rgba(212, 175, 55, 0.4);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.venue-card:hover {
+  transform: translateY(-8px);
+  box-shadow: 0 24px 40px rgba(18, 62, 45, 0.16);
+}
+
+.media {
+  background: linear-gradient(140deg, rgba(18, 62, 45, 0.85), rgba(212, 175, 55, 0.75));
+  height: 180px;
+  position: relative;
+}
+
+.media::after {
+  content: '';
+  position: absolute;
+  inset: 16px;
+  border: 2px dashed rgba(248, 243, 231, 0.8);
+  border-radius: var(--radius-md);
+}
+
+.media .badge {
+  position: absolute;
+  top: 16px;
+  left: 16px;
+  background: var(--color-gold);
+  color: var(--color-primary);
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.card-body {
+  padding: var(--spacing-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  height: 100%;
+}
+
+.card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--spacing-md);
+}
+
+.card-top h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 1.2rem;
+}
+
+.icon-btn {
+  background: none;
+  border: 1px solid rgba(18, 62, 45, 0.2);
+  border-radius: 999px;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+
+.meta {
+  font-size: 0.9rem;
+  color: rgba(51, 51, 51, 0.75);
+}
+
+.amenities {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  font-size: 0.85rem;
+}
+
+.card-footer {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+}
+
+.price {
+  display: grid;
+  gap: 4px;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.rating {
+  font-size: 0.9rem;
+  color: var(--color-gold);
+}
+
+.flow {
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--spacing-lg);
+}
+
+.steps li {
+  background: var(--color-bg);
+  border: 1px solid rgba(212, 175, 55, 0.35);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  position: relative;
+  box-shadow: var(--shadow-soft);
+}
+
+.step-number {
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: var(--color-white);
+  font-weight: 600;
+  margin-bottom: var(--spacing-md);
+}
+
+.calendar-demo {
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+.calendar-widget {
+  background: var(--color-white);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(212, 175, 55, 0.35);
+  box-shadow: var(--shadow-soft);
+  padding: var(--spacing-xl);
+  display: grid;
+  gap: var(--spacing-lg);
+}
+
+.calendar-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.calendar-header button {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--color-primary);
+}
+
+.calendar-header .month {
+  font-family: var(--font-heading);
+  font-size: 1.2rem;
+}
+
+.legend {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-left: var(--spacing-lg);
+  font-size: 0.85rem;
+}
+
+.dot {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.dot.available {
+  background: var(--color-primary);
+}
+
+.dot.partial {
+  background: linear-gradient(90deg, var(--color-primary) 50%, #e53935 50%);
+}
+
+.dot.booked {
+  background: #e53935;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 8px;
+}
+
+.day {
+  font-weight: 600;
+  text-align: center;
+  color: rgba(51, 51, 51, 0.7);
+}
+
+.cell {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(18, 62, 45, 0.2);
+  background: var(--color-white);
+  min-height: 120px;
+  display: grid;
+  gap: 8px;
+  padding: 12px;
+  text-align: left;
+  font-family: var(--font-body);
+}
+
+.cell.available {
+  border-color: rgba(18, 62, 45, 0.4);
+}
+
+.cell.available:hover,
+.cell.available:focus-visible {
+  outline: 2px solid var(--color-gold);
+  outline-offset: 2px;
+}
+
+.cell.partial {
+  background: linear-gradient(135deg, rgba(18, 62, 45, 0.12), rgba(229, 57, 53, 0.08));
+}
+
+.cell.booked {
+  background: rgba(229, 57, 53, 0.15);
+  color: rgba(51, 51, 51, 0.6);
+}
+
+.cell.booked .slot {
+  background: rgba(229, 57, 53, 0.2);
+}
+
+.cell.muted {
+  color: rgba(51, 51, 51, 0.4);
+  display: grid;
+  place-items: center;
+}
+
+.date {
+  font-weight: 600;
+}
+
+.slots {
+  display: grid;
+  gap: 6px;
+  font-size: 0.75rem;
+}
+
+.slot {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(18, 62, 45, 0.15);
+  color: var(--color-primary);
+  text-align: center;
+}
+
+.slot.disabled {
+  background: rgba(229, 57, 53, 0.2);
+  color: #a73434;
+}
+
+.slot-panel {
+  border-top: 1px solid rgba(18, 62, 45, 0.1);
+  padding-top: var(--spacing-lg);
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.slot-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.slot-chip {
+  border-radius: 999px;
+  border: 1px solid rgba(18, 62, 45, 0.4);
+  padding: 0.5rem 1rem;
+  background: rgba(18, 62, 45, 0.08);
+  font-family: var(--font-body);
+  cursor: pointer;
+}
+
+.slot-chip.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.hold-timer {
+  font-weight: 500;
+  color: var(--color-primary);
+}
+
+.blog {
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--spacing-lg);
+}
+
+.blog-card {
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(212, 175, 55, 0.35);
+  padding: var(--spacing-lg);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: var(--spacing-md);
+}
+
+.blog-card h3 {
+  margin: 0;
+  font-family: var(--font-heading);
+}
+
+.link {
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.section.cta {
+  text-align: center;
+  background: linear-gradient(135deg, rgba(18, 62, 45, 0.92), rgba(18, 62, 45, 0.75));
+  color: var(--color-white);
+  padding: 100px 0;
+}
+
+.section.cta .btn.secondary {
+  background: var(--color-white);
+  color: var(--color-primary);
+}
+
+.site-footer {
+  background: #0d271d;
+  color: rgba(255, 255, 255, 0.8);
+  padding: var(--spacing-lg) 0;
+}
+
+.footer-inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-sm);
+}
+
+.social-links {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+.social-links a {
+  font-weight: 500;
+}
+
+@media (max-width: 960px) {
+  .main-nav {
+    position: fixed;
+    inset: 0 0 auto;
+    background: var(--color-white);
+    flex-direction: column;
+    padding: var(--spacing-xl);
+    gap: var(--spacing-lg);
+    transform: translateY(-100%);
+    transition: transform 0.3s ease;
+  }
+
+  .main-nav.open {
+    transform: translateY(0);
+  }
+
+  .auth-actions {
+    display: none;
+  }
+
+  .mobile-menu {
+    display: inline-flex;
+  }
+
+  .mobile-menu.open span:nth-child(1) {
+    transform: translateY(8px) rotate(45deg);
+  }
+
+  .mobile-menu.open span:nth-child(2) {
+    opacity: 0;
+  }
+
+  .mobile-menu.open span:nth-child(3) {
+    transform: translateY(-8px) rotate(-45deg);
+  }
+
+  .hero {
+    padding-top: 160px;
+  }
+
+  .search-card {
+    padding: var(--spacing-lg);
+  }
+}
+
+@media (max-width: 600px) {
+  .field.grid {
+    grid-template-columns: 1fr;
+  }
+
+  .calendar-widget {
+    padding: var(--spacing-lg);
+  }
+
+  .calendar-grid {
+    gap: 4px;
+  }
+
+  .cell {
+    min-height: 100px;
+    padding: 10px;
+  }
+}

--- a/docs/toyimbor-design-brief.md
+++ b/docs/toyimbor-design-brief.md
@@ -1,0 +1,215 @@
+# To'yimBor — To'liq umumiylashtirilgan dizayn va texnik brief
+
+## 1. Loyihaning umumiy maqsadi va ruhiyati
+- **Maqsad:** Foydalanuvchilarga hududdagi to'yxonalarni qidirish, bo'sh sanalarni ko'rish, 2 slot/kun (ertalab/kechki) bo'yicha band qilish va onlayn to'lov orqali tasdiqlash imkonini berish.
+- **Ruhiyat:** Zamonaviy, hashamatli, milliy naqsh elementlari bilan boyitilgan tajriba. Brend ranglari — yashil va oltin kombinatsiyasi.
+
+## 2. Brend tokenlari (Colors & Typography)
+- **Rang palitrasi:**
+  - Dark green (primary): `#123E2D`
+  - Oltin (accent): `#D4AF37`
+  - Bej (fon): `#F8F3E7`
+  - Oq: `#FFFFFF`
+  - To'q kulrang (matn): `#333333`
+- **Shriftlar:**
+  - Sarlavhalar: Montserrat SemiBold
+  - Body matn: Poppins Regular / Medium
+- **Spacing & radius:** Spacing scale 4 / 8 / 16 / 24 / 32; border-radius 12–16px; soyalar: `0 4px 12px rgba(0,0,0,0.06)`.
+
+## 3. Sahifalar va umumiy struktura
+1. Homepage (Hero + Qidiruv + Popular cards + Blog preview)
+2. Catalog / To'yxonalar (filter + card grid)
+3. To'yxona profil (galereya, tafsilot, inline calendar)
+4. Modal / Booking flow (card → venue modal → calendar popup → payment modal → confirmation)
+5. Profil (foydalanuvchi bookinglari)
+6. Admin / Venue owner panel
+7. Blog, Auth, Footer
+
+## 4. Header, qidiruv paneli va filtrlar
+**Header (desktop):**
+- Chapda: Logo (SVG)
+- Markazda: Navigatsiya (`Bosh sahifa | To'yxonalar | Blog | Aloqa`)
+- O'ngda: Kirish / Ro'yxatdan o'tish / Profil tugmalari
+
+**Qidiruv paneli (hero ostida yoki ichida):**
+1. Joy nomi yoki to'yxona nomi — matn (autosuggest). Placeholder: `🔍 Joy nomi, to'yxona yoki xizmat qidiring`
+2. Sana — datepicker. Placeholder: `📅 Sanani tanlang`
+3. Filter tugmasi — narx, sig'im, joylashuv, qo'shimcha xizmatlar uchun modalni chaqiradi
+4. Qidirish tugmasi — primary (`#123E2D` fon, oq matn)
+
+**Behavior:** Sana tanlansa, backend shu sanadagi bo'sh to'yxonalarni qaytaradi. Sana kiritilmasa, barcha to'yxonalar (filtrlar bo'yicha) ko'rsatiladi.
+
+## 5. Filter modalining detali
+- **Elementlar:** Narx (min-max slider), Sig'im (slider yoki dropdown), Joylashuv (shahar/tuman), Sana (ikkinchi input), Qulayliklar (checkbox: parking, dekor, AC, wifi).
+- **UX:** "Filtrni qo'llash" tugmasi; natijalar server-side yoki client-side tarzda yangilanadi.
+
+## 6. To'yxona kartasi (Card) dizayni
+- **Grid:** Desktopda 3–4 kolonka (responsive).
+- **Kontent:**
+  - Media carousel: 3–4 rasm yoki video (16:9), video autoplay off, poster fallback, thumbnail navigatsiya.
+  - Nomi (Montserrat SemiBold)
+  - Qisqacha izoh: sig'im, joylashuv, asosiy qulayliklar (parking, dekor, AC).
+  - Narx (masalan: `6 500 000 so'mdan`)
+  - Reyting: yulduzchalar + raqam (masalan, 4.8)
+  - CTA: "Band qilish" (yashil, primary)
+  - Save/favorite ikonkasi (bookmark)
+- **Vizual effektlar:** Milliy naqshli oltin border; hoverda lifti va soyasi, CTA yorqinlashadi.
+
+## 7. Card → Modal (To'yxona tafsilotlari)
+- **Trigger:** Kartaga yoki "Band qilish" tugmasiga bosilganda.
+- **Modal dizayni:** Markazda, maksimal kenglik 950–1100px, milliy naqshli oltin border.
+- **Desktop layout:**
+  - Chap (60%): Katta image/video carousel
+  - O'ng (40%): Nomi, joylashuv (map link), reyting, sig'im, qulayliklar (ikonlar), narx oralig'i, batafsil tavsif (200–400 belgi), CTA, kontaktlar/ijtimoiy linklar
+- **Mobile:** Fullscreen modal, rasm → tafsilotlar → CTA tartibida.
+
+## 8. Calendar popup (band qilish)
+- **Title:** "Band qilish uchun sanani tanlang"
+- **Grid:** 7 × 6 oy ko'rinishi
+- **Cell holatlari:**
+  - To'liq band: qizil (`#E53935`) — disabled
+  - To'liq bo'sh: yashil (`#2E7D32` yoki `#123E2D`) — selectable
+  - Yarmi bo'sh: slot indikatorlari (yashil/qizil chiplar)
+  - O'tgan kunlar: kulrang, disabled
+- **Slot tanlash UI:** Calendar ostida yoki yon panelda ertalab (10:00–15:00) va kechki (17:00–22:00) slotlari. Har bir slot uchun `available: boolean`.
+- **Hold timer:** Slot tanlanganda backend hold yaratadi (10 daqiqa). UI: countdown (`Rezervni yakunlash uchun: 09:45`).
+- **Booking tugmasi:** Slot tanlanganda faollashadi.
+- **Konfirmatsiya:** Muvaffaqiyatli holatda booking summary + booking id + to'lov tugmasi.
+
+## 9. To'lov modal va integratsiya
+- **To'lov bosqichi:**
+  - Ko'rsatadi: to'yxona nomi, sana va slot, narx.
+  - To'lov usullari: Click, Payme, Uzum, bank kartalari/Stripe (kelajak).
+  - To'lov amalga oshirilgach, gateway redirect yoki in-place widget orqali yakunlanadi.
+- **API flow:**
+  1. `POST /api/payments/initiate` → `payment_url` yoki `payment_session`
+  2. Foydalanuvchi to'lovni tugatadi → gateway webhook `POST /api/payments/webhook`
+  3. To'lov muvaffaqiyatli → `POST /api/bookings/confirm (hold_id)` → booking tasdiqlanadi
+- **UI:** Success modal + booking id + "Profilga o'tish" tugmasi. Xato holatlarda retry yoki qo'llab-quvvatlash.
+
+## 10. Profil (foydalanuvchi bookinglari)
+- **Bo'lim:** "Mening band qilgan to'yxonalarim"
+- **Booking kartasi:** Rasm, to'yxona nomi, sana + slot, status (✅ Tasdiqlangan / ⏳ Kutilyapti / ❌ Bekor qilingan), booking id, to'lov miqdori, "Tafsilot" va "Bekor qilish" tugmalari.
+- **Qo'shimcha:** Tarix va receipt (PDF download) imkoniyati.
+
+## 11. Backend / API va data modeli
+- **Endpointlar:**
+  - `GET /api/venues/search?q=&location=&date=YYYY-MM-DD&min_price=&max_price=&capacity=`
+  - `GET /api/venues/{id}`
+  - `GET /api/venues/{id}/availability?month=YYYY-MM`
+  - `POST /api/bookings/hold` → `{ hold_id, expires_at }`
+  - `POST /api/payments/initiate` → `{ payment_url, session_id }`
+  - `POST /api/bookings/confirm`
+  - `POST /api/payments/webhook`
+- **Sample venue JSON:**
+```json
+{
+  "id": 123,
+  "name": "Afsonaviy To'yxona",
+  "location": "Qarshi, Mustaqillik ko'chasi",
+  "images": ["img1.jpg", "img2.jpg", "img3.jpg"],
+  "videos": ["promo.mp4"],
+  "capacity": 500,
+  "price_min": 6500000,
+  "price_max": 12000000,
+  "rating": 4.8,
+  "amenities": ["parking", "decor", "ac", "wifi"],
+  "availability": {
+    "2025-08-18": [
+      { "slot": "morning", "time": "10:00-15:00", "available": true },
+      { "slot": "evening", "time": "17:00-22:00", "available": false }
+    ]
+  }
+}
+```
+- **Sample booking hold / confirm:**
+```json
+POST /api/bookings/hold
+{
+  "venue_id": 123,
+  "date": "2025-08-18",
+  "slot": "evening",
+  "user_id": 456
+}
+>> Response:
+{
+  "hold_id": "HLD_7890",
+  "expires_at": "2025-07-01T12:34:56Z"
+}
+
+POST /api/bookings/confirm
+{
+  "hold_id": "HLD_7890",
+  "payment_id": "PAY_4567",
+  "payment_status": "success"
+}
+>> Response:
+{
+  "booking_id": "BK_1001",
+  "status": "confirmed"
+}
+```
+
+## 12. Booking biznes qoidalari va concurrency
+- Kuniga 2 slot (morning/evening), har slot mustaqil.
+- Hold mexanizmi: hold yaratganda slot 10 daqiqa muddatga ajratiladi; UI countdown ko'rsatadi.
+- Booking tasdiqlash: DB darajasida single transaction, double-book'ni oldini olish.
+- Admin override: Admin/venue owner availabilityni qo'lda o'zgartira oladi.
+
+## 13. UI komponentlar ro'yxati (Figma/Dev)
+- Buttons: Primary / Secondary / Disabled / Icon
+- Inputs: Text, Datepicker, Number, Slider
+- Card: Venue card (media carousel + meta + CTA)
+- Modallar: Venue modal, Calendar modal, Payment modal, Confirmation dialog
+- Calendar cell variantlari: disabled, selected, available, partial-available, today
+- Chips / Tags: Amenities
+- Icons: yulduz, joylashuv, telefon, kalendar, favorite, filter
+- Tokens: color, typography, spacing, elevation
+
+## 14. Figma handoff — structure & naming
+- File: `ToyimBor / UI Kit`
+- Pages: `00-Design System`, `01-Homepage`, `02-Catalog`, `03-Venue-Modal`, `04-Calendar`, `05-Booking-Flow`, `06-Mobile`
+- Component naming: `Button/Primary/Default`, `Card/Venue/Default`, `Modal/Venue/Default`, `Calendar/Cell/Available`
+- Exportlar: SVG ikonlar, JPG/PNG media (1x & 2x), tokens JSON.
+
+## 15. Responsive va Accessibility talablar
+- Breakpointlar: Desktop 1440px, Tablet 768px, Mobile 375px.
+- Touch targetlar ≥ 44–48px.
+- Klaviatura va ARIA: modal dialoglar `role="dialog"`, `aria-modal="true"`, focus trap; calendar cell'lar keyboard-selectable; ESC bilan yopish.
+- Kontrast tekshiruvi: oltin rang yorqin fonlarda test qilinadi.
+- Lokalizatsiya: `uz-Latin` formatdagi sanalar va matnlar.
+
+## 16. UX flow'lar (asosiy ssenariy)
+1. Foydalanuvchi homepage → joy yoki to'yxona nomini yozadi + sana tanlaydi → qidirish.
+2. Natijalar: shu sana uchun `available: true` bo'lgan to'yxonalar qaytariladi.
+3. Kartaga bosadi → venue modal ochiladi → tafsilotlarni ko'rib "Band qilish"ni tanlaydi.
+4. Calendar modal → sana + slot tanlanadi → "Band qilish" → hold yaratiladi (10 daqiqa countdown).
+5. Payment modal → to'lov → webhook orqali booking tasdiqlanadi → profilga qo'shiladi + confirmation.
+6. Venue owner admin panelida bookinglar aks etadi.
+
+## 17. Notifications va qo'shimcha imkoniyatlar
+- Email/SMS/Telegram notificationalari: booking, confirmation, cancellation uchun.
+- Receipt PDF download.
+- Admin analytics: search → view → hold → confirm funnel metrikalari.
+
+## 18. Assetlar ro'yxati
+- Logo (SVG color & mono)
+- Milliy naqsh SVG (tileable pattern)
+- Color va typography tokens (JSON)
+- Har bir to'yxona uchun 3–4 rasm + 1 video
+- Icon set (SVG)
+- Uzbek copy strings (placeholderlar, xato va success matnlari)
+
+## 19. Deliverables
+- PDF Design Brief (tayyor) ✅
+- Figma UI Kit + sahifalar (Homepage, Catalog, Venue Modal, Calendar, Booking flow)
+- Interactive Figma prototype (card → modal → calendar → payment)
+- Developer spec + mock API (JSON)
+- Minimal React demo (frontend prototype) — ixtiyoriy.
+
+## 20. Key next qadamlar
+1. Dizaynerga Figma UI Kit + frames topshirish.
+2. Backend: availability modeli, booking hold/confirm, payment gateway integratsiyasi.
+3. Frontend: card grid, modal, calendar component, payment flow.
+4. Test: concurrency (double-book), hold timeout, cross-device, accessibility.
+5. Marketing: blog va social media content tayyorlash.


### PR DESCRIPTION
## Summary
- create a branded To'yimBor demo landing page highlighting search, venue cards, calendar, and blog sections
- add responsive styling, typography, and interactive calendar/slot showcase for the demo
- link the new demo page from the README for quick discovery

## Testing
- not run (static demo page)


------
https://chatgpt.com/codex/tasks/task_e_68e8a67030d48327b0ed68d622388346